### PR TITLE
URL Cleanup

### DIFF
--- a/boot/boot-fsshell/build.gradle
+++ b/boot/boot-fsshell/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/libs-release" }
+        maven { url "https://repo.spring.io/libs-release" }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.3.RELEASE")
@@ -16,7 +16,7 @@ apply plugin: 'spring-boot'
 
 repositories {
     mavenCentral()
-    maven { url "http://repo.spring.io/libs-release" }
+    maven { url "https://repo.spring.io/libs-release" }
 }
 
 dependencies {

--- a/boot/boot-fsshell/pom.xml
+++ b/boot/boot-fsshell/pom.xml
@@ -43,7 +43,7 @@
     <repositories>
         <repository>
             <id>spring-release</id>
-            <url>http://repo.spring.io/libs-release</url>
+            <url>https://repo.spring.io/libs-release</url>
             <snapshots><enabled>false</enabled></snapshots>
         </repository>
     </repositories>
@@ -51,7 +51,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>spring-release</id>
-            <url>http://repo.spring.io/libs-release</url>
+            <url>https://repo.spring.io/libs-release</url>
             <snapshots><enabled>false</enabled></snapshots>
         </pluginRepository>
     </pluginRepositories>

--- a/boot/yarn-boot-simple/build.gradle
+++ b/boot/yarn-boot-simple/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/libs-release" }
+        maven { url "https://repo.spring.io/libs-release" }
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.3.RELEASE")
@@ -16,7 +16,7 @@ apply plugin: 'spring-boot'
 
 repositories {
     mavenCentral()
-    maven { url "http://repo.spring.io/libs-release" }
+    maven { url "https://repo.spring.io/libs-release" }
 }
 
 dependencies {

--- a/boot/yarn-store-groups/build.gradle
+++ b/boot/yarn-store-groups/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/libs-release" }
+		maven { url "https://repo.spring.io/libs-release" }
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.3.RELEASE")
@@ -18,7 +18,7 @@ subprojects { subproject ->
 	version =  '0.1.0'
 	repositories {
 		mavenCentral()
-		maven { url "http://repo.spring.io/libs-release" }
+		maven { url "https://repo.spring.io/libs-release" }
 	}
 	task copyJars(type: Copy) {
 		from "$buildDir/libs"

--- a/boot/yarn-store-groups/pom.xml
+++ b/boot/yarn-store-groups/pom.xml
@@ -51,7 +51,7 @@
     <repositories>
         <repository>
             <id>spring-release</id>
-            <url>http://repo.spring.io/libs-release</url>
+            <url>https://repo.spring.io/libs-release</url>
             <snapshots><enabled>false</enabled></snapshots>
         </repository>
     </repositories>
@@ -59,7 +59,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>spring-release</id>
-            <url>http://repo.spring.io/libs-release</url>
+            <url>https://repo.spring.io/libs-release</url>
             <snapshots><enabled>false</enabled></snapshots>
         </pluginRepository>
     </pluginRepositories>

--- a/dataset/pom.xml
+++ b/dataset/pom.xml
@@ -44,7 +44,7 @@
 	<repositories>
 	    <repository>
 	        <id>spring-milestones</id>
-	        <url>http://repo.spring.io/libs-release</url>
+	        <url>https://repo.spring.io/libs-release</url>
 	    </repository>
 	</repositories>
 

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -73,7 +73,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hive-batch/pom.xml
+++ b/hive-batch/pom.xml
@@ -86,7 +86,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.spring.io/libs-milestone</url>
+			<url>https://repo.spring.io/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -134,7 +134,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.spring.io/libs-milestone</url>
+			<url>https://repo.spring.io/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/mapreduce/pom.xml
+++ b/mapreduce/pom.xml
@@ -198,15 +198,15 @@
 	<repositories>	
 		<repository>
 			<id>hortonworks</id>
-			<url>http://repo.hortonworks.com/content/repositories/releases</url>
+			<url>https://repo.hortonworks.com/content/repositories/releases</url>
 		</repository>
 		<repository>
 			<id>hortonworks-jetty</id>
-			<url>http://repo.hortonworks.com/content/repositories/jetty-hadoop</url>
+			<url>https://repo.hortonworks.com/content/repositories/jetty-hadoop</url>
 		</repository>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.spring.io/libs-milestone</url>
+			<url>https://repo.spring.io/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/mr-batch/pom.xml
+++ b/mr-batch/pom.xml
@@ -58,7 +58,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.spring.io/libs-milestone</url>
+			<url>https://repo.spring.io/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -137,7 +137,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestones</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -104,7 +104,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestone</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 		</repository>
 	</repositories>
 

--- a/yarn/build.gradle
+++ b/yarn/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'base'
 
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-release" }
+		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
 		classpath("org.springframework.build.gradle:docbook-reference-plugin:0.2.6")
@@ -18,7 +18,7 @@ allprojects {
  
 	repositories {
 		mavenCentral()
-		maven { url 'http://repo.spring.io/libs-release' }
+		maven { url 'https://repo.spring.io/libs-release' }
 	}
 }
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.hortonworks.com/content/repositories/jetty-hadoop migrated to:  
  https://repo.hortonworks.com/content/repositories/jetty-hadoop ([https](https://repo.hortonworks.com/content/repositories/jetty-hadoop) result 302).
* http://repo.hortonworks.com/content/repositories/releases migrated to:  
  https://repo.hortonworks.com/content/repositories/releases ([https](https://repo.hortonworks.com/content/repositories/releases) result 302).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-release migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance