### PR TITLE
URL Cleanup

### DIFF
--- a/boot/yarn-boot-simple/LICENSE.code.txt
+++ b/boot/yarn-boot-simple/LICENSE.code.txt
@@ -6,7 +6,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/hbase/src/main/java/org/springframework/samples/hadoop/hbase/UserApp.java
+++ b/hbase/src/main/java/org/springframework/samples/hadoop/hbase/UserApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hive-batch/src/main/java/org/springframework/samples/hadoop/hive/HiveBatchApp.java
+++ b/hive-batch/src/main/java/org/springframework/samples/hadoop/hive/HiveBatchApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hive/src/main/java/org/springframework/samples/hadoop/hive/HiveApp.java
+++ b/hive/src/main/java/org/springframework/samples/hadoop/hive/HiveApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hive/src/main/java/org/springframework/samples/hadoop/hive/HiveAppWithApacheLogs.java
+++ b/hive/src/main/java/org/springframework/samples/hadoop/hive/HiveAppWithApacheLogs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/hive/src/main/java/org/springframework/samples/hadoop/hive/HiveClientApp.java
+++ b/hive/src/main/java/org/springframework/samples/hadoop/hive/HiveClientApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mapreduce/src/main/java/org/springframework/samples/hadoop/mapreduce/Wordcount.java
+++ b/mapreduce/src/main/java/org/springframework/samples/hadoop/mapreduce/Wordcount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mr-batch/src/main/java/org/springframework/samples/hadoop/mapreduce/HashtagCount.java
+++ b/mr-batch/src/main/java/org/springframework/samples/hadoop/mapreduce/HashtagCount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mr-batch/src/main/java/org/springframework/samples/hadoop/mapreduce/MrBatchApp.java
+++ b/mr-batch/src/main/java/org/springframework/samples/hadoop/mapreduce/MrBatchApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pig/src/main/java/org/springframework/samples/hadoop/pig/PigApp.java
+++ b/pig/src/main/java/org/springframework/samples/hadoop/pig/PigApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pig/src/main/java/org/springframework/samples/hadoop/pig/PigAppWithApacheLogs.java
+++ b/pig/src/main/java/org/springframework/samples/hadoop/pig/PigAppWithApacheLogs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/pig/src/main/java/org/springframework/samples/hadoop/pig/PigAppWithRepository.java
+++ b/pig/src/main/java/org/springframework/samples/hadoop/pig/PigAppWithRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/batch-amjob/src/main/java/org/springframework/yarn/examples/PrintTasklet.java
+++ b/yarn/yarn/batch-amjob/src/main/java/org/springframework/yarn/examples/PrintTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/batch-amjob/src/test/java/org/springframework/yarn/examples/BatchAmjobTests.java
+++ b/yarn/yarn/batch-amjob/src/test/java/org/springframework/yarn/examples/BatchAmjobTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/batch-files/src/main/java/org/springframework/yarn/examples/LoggingItemWriter.java
+++ b/yarn/yarn/batch-files/src/main/java/org/springframework/yarn/examples/LoggingItemWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/batch-files/src/main/java/org/springframework/yarn/examples/PrintTasklet.java
+++ b/yarn/yarn/batch-files/src/main/java/org/springframework/yarn/examples/PrintTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/batch-files/src/test/java/org/springframework/yarn/examples/BatchFilesTests.java
+++ b/yarn/yarn/batch-files/src/test/java/org/springframework/yarn/examples/BatchFilesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/batch-partition/src/main/java/org/springframework/yarn/examples/PrintTasklet.java
+++ b/yarn/yarn/batch-partition/src/main/java/org/springframework/yarn/examples/PrintTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/batch-partition/src/test/java/org/springframework/yarn/examples/BatchPartitionTests.java
+++ b/yarn/yarn/batch-partition/src/test/java/org/springframework/yarn/examples/BatchPartitionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/custom-amservice/src/main/java/org/springframework/yarn/examples/CustomAppmaster.java
+++ b/yarn/yarn/custom-amservice/src/main/java/org/springframework/yarn/examples/CustomAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/custom-amservice/src/main/java/org/springframework/yarn/examples/CustomAppmasterService.java
+++ b/yarn/yarn/custom-amservice/src/main/java/org/springframework/yarn/examples/CustomAppmasterService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/custom-amservice/src/main/java/org/springframework/yarn/examples/CustomContainer.java
+++ b/yarn/yarn/custom-amservice/src/main/java/org/springframework/yarn/examples/CustomContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/custom-amservice/src/main/java/org/springframework/yarn/examples/JobRequest.java
+++ b/yarn/yarn/custom-amservice/src/main/java/org/springframework/yarn/examples/JobRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/custom-amservice/src/main/java/org/springframework/yarn/examples/JobResponse.java
+++ b/yarn/yarn/custom-amservice/src/main/java/org/springframework/yarn/examples/JobResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/custom-amservice/src/test/java/org/springframework/yarn/examples/CustomAmserviceTests.java
+++ b/yarn/yarn/custom-amservice/src/test/java/org/springframework/yarn/examples/CustomAmserviceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/kill-application/src/main/java/org/springframework/yarn/examples/KillApplicationContainer.java
+++ b/yarn/yarn/kill-application/src/main/java/org/springframework/yarn/examples/KillApplicationContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/kill-application/src/main/java/org/springframework/yarn/examples/Main.java
+++ b/yarn/yarn/kill-application/src/main/java/org/springframework/yarn/examples/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/kill-application/src/test/java/org/springframework/yarn/examples/KillApplicationTests.java
+++ b/yarn/yarn/kill-application/src/test/java/org/springframework/yarn/examples/KillApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/list-applications/src/main/java/org/springframework/yarn/examples/Main.java
+++ b/yarn/yarn/list-applications/src/main/java/org/springframework/yarn/examples/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/list-applications/src/test/java/org/springframework/yarn/examples/ListApplicationsTests.java
+++ b/yarn/yarn/list-applications/src/test/java/org/springframework/yarn/examples/ListApplicationsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/multi-context/src/main/java/org/springframework/yarn/examples/AppmasterConfiguration.java
+++ b/yarn/yarn/multi-context/src/main/java/org/springframework/yarn/examples/AppmasterConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/multi-context/src/main/java/org/springframework/yarn/examples/ClientConfiguration.java
+++ b/yarn/yarn/multi-context/src/main/java/org/springframework/yarn/examples/ClientConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/multi-context/src/main/java/org/springframework/yarn/examples/ContainerConfiguration.java
+++ b/yarn/yarn/multi-context/src/main/java/org/springframework/yarn/examples/ContainerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/multi-context/src/main/java/org/springframework/yarn/examples/MultiContextContainer.java
+++ b/yarn/yarn/multi-context/src/main/java/org/springframework/yarn/examples/MultiContextContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/multi-context/src/test/java/org/springframework/yarn/examples/MultiContextJavaConfigTests.java
+++ b/yarn/yarn/multi-context/src/test/java/org/springframework/yarn/examples/MultiContextJavaConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/multi-context/src/test/java/org/springframework/yarn/examples/MultiContextTests.java
+++ b/yarn/yarn/multi-context/src/test/java/org/springframework/yarn/examples/MultiContextTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/multi-context/src/test/java/org/springframework/yarn/examples/MultiContextXmlConfigTests.java
+++ b/yarn/yarn/multi-context/src/test/java/org/springframework/yarn/examples/MultiContextXmlConfigTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/restart-context/src/main/java/org/springframework/yarn/examples/CustomAppmaster.java
+++ b/yarn/yarn/restart-context/src/main/java/org/springframework/yarn/examples/CustomAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/restart-context/src/main/java/org/springframework/yarn/examples/FailingContextContainer.java
+++ b/yarn/yarn/restart-context/src/main/java/org/springframework/yarn/examples/FailingContextContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/restart-context/src/test/java/org/springframework/yarn/examples/RestartContextTests.java
+++ b/yarn/yarn/restart-context/src/test/java/org/springframework/yarn/examples/RestartContextTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/simple-command/src/test/java/org/springframework/yarn/examples/SimpleCommandTests.java
+++ b/yarn/yarn/simple-command/src/test/java/org/springframework/yarn/examples/SimpleCommandTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/yarn/yarn/src/main/java/org/springframework/yarn/examples/CommonMain.java
+++ b/yarn/yarn/src/main/java/org/springframework/yarn/examples/CommonMain.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 42 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).